### PR TITLE
switch fog dependency to fog-aws as recommended by that gem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,9 @@
+2.5.0 (July 18th, 2018)
+ - Change fog dependency to fog-aws
+
+2.4.0 (July 17th, 2018)
+ - Add 'private_template' option for securely passing git credentials.
+
 2.3.3 (January 19th, 2016)
  - BUGFIX: Explicitly specify Jekyll output directory within
    temporary directory

--- a/lib/stevenson/deployers/s3.rb
+++ b/lib/stevenson/deployers/s3.rb
@@ -1,4 +1,4 @@
-require 'fog'
+require 'fog/aws'
 
 module Stevenson
   module Deployer

--- a/lib/stevenson/version.rb
+++ b/lib/stevenson/version.rb
@@ -1,3 +1,3 @@
 module Stevenson
-  VERSION = "2.4.0"
+  VERSION = "2.5.0"
 end

--- a/stevenson.gemspec
+++ b/stevenson.gemspec
@@ -24,7 +24,7 @@ Gem::Specification.new do |spec|
 
   spec.add_dependency "cocaine", "~> 0.5"
   spec.add_dependency "git"
-  spec.add_dependency "fog"
+  spec.add_dependency "fog-aws", "~> 3.0"
   spec.add_dependency "hashie"
   spec.add_dependency "highline"
   spec.add_dependency "jekyll"


### PR DESCRIPTION
the `fog` gem recommends only importing the provider-specific gems.